### PR TITLE
Fix module exports and tests for chapter 8 exercise

### DIFF
--- a/ch8-bugs/retry.js
+++ b/ch8-bugs/retry.js
@@ -20,7 +20,6 @@ function reliableMultiply(a, b) {
     for (;;) {
         try {
             let result = primitiveMultiply(a, b);
-            console.log(`${a} * ${b} = ${result}`);
             return result;
         } catch (error) {
             if (!(error instanceof MultiplicatorUnitFailure)) throw error;
@@ -28,6 +27,4 @@ function reliableMultiply(a, b) {
     }
 }
 
-module.exports = { MultiplicatorUnitFailure };
-exports.reliableMultiply = reliableMultiply;
-exports.primitiveMultiply = primitiveMultiply;
+module.exports = { MultiplicatorUnitFailure, reliableMultiply };

--- a/tests/retry.test.js
+++ b/tests/retry.test.js
@@ -1,5 +1,6 @@
 const retry = require('../ch8-bugs/retry');
 
-test('only return result if call succeeds', () => {
-    let result = retry.reliableMultiply(8, 8);
+test('only return result if call succeeds', async () => {
+  const result = await retry.reliableMultiply(8, 8);
+  expect(result).toBe(64);
 });


### PR DESCRIPTION
Merging this PR will change how the `reliableMultiply` function is exported and the jest tests run.